### PR TITLE
Update requirements.txt to pin the version of utils3d

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ mediapy
 scikit-image
 pycolmap==3.11.1
 git+https://github.com/facebookresearch/segment-anything.git
-git+https://github.com/EasternJournalist/utils3d.git#egg=utils3d
+git+https://github.com/EasternJournalist/utils3d.git@d3a577acf0a9ad7e513a1416449a07b6f47d967f#egg=utils3d
 huggingface_hub
 pyceres==2.4
 kornia==0.8.1


### PR DESCRIPTION
 Update requirements.txt to pin the version of utils3d to an older version with utils3d.torch.depth_edge

SpaTrack.py uses utils3d.torch.depth_edge, which is no longer present in utils3d; it was removed in https://github.com/EasternJournalist/utils3d/commit/5cb6a142d6b3a907a47ad0f0aa72f52e77ed34dd, so pinning the requirements to a commit before this change.